### PR TITLE
Only log failure to set node-role label

### DIFF
--- a/pkg/boatswain/replace_node.go
+++ b/pkg/boatswain/replace_node.go
@@ -33,7 +33,8 @@ func ReplaceAsgNode(awsClient *aws.AwsClient, k8sClient *k8sclient.K8sClient,
 	// 4. Ensure node-role labels exist on new node
 	fmt.Println("Set node-role.kubernetes.io labels on new node")
 	if err := k8sClient.SetNodeRoles(newNode); err != nil {
-		return err
+		fmt.Printf("Failed to set node roles for %v, continuing...\n",
+			newNode.ObjectMeta.Name)
 	}
 	fmt.Printf("New node %v ready\n", newNode.ObjectMeta.Name)
 	// 5. Drain old node


### PR DESCRIPTION
This is not a critical error, as node-roles can easily be added
manually after the maintenance.

We will need to investigate a proper fix at some point, but this change
will allow the maintenance to complete, even if some nodes may not get
the nice visible node-role label that's used by kubectl.

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Link this PR to related issues.