### PR TITLE
Make roleArn optional

### DIFF
--- a/pkg/aws/init.go
+++ b/pkg/aws/init.go
@@ -13,8 +13,11 @@ func NewAwsClient(roleArn string) *AwsClient {
 	c := &AwsClient{}
 
 	c.Session = session.New()
-	creds := stscreds.NewCredentials(c.Session, roleArn)
-	c.Config = &aws.Config{Credentials: creds}
+
+	if roleArn != "" {
+		creds := stscreds.NewCredentials(c.Session, roleArn)
+		c.Config = &aws.Config{Credentials: creds}
+	}
 
 	c.AutoScaling = autoscaling.New(c.Session, c.Config)
 	c.EC2 = ec2.New(c.Session, c.Config)


### PR DESCRIPTION
Not all clusters are installed impersonated via a role.
An empty string AWS_ASSUME_ROLE_ARN must be allowed.

- [x] Keep pull requests small so they can be easily reviewed.
