### PR TITLE
Improve error reporting

### DIFF
--- a/cmd/boatswain/check_ami.go
+++ b/cmd/boatswain/check_ami.go
@@ -9,7 +9,7 @@ import (
 func (b *Boatswain) CheckAmi(eksVersionOverride string) error {
 	eksVersion, err := b.K8sClient.GetServerVersion()
 	if err != nil {
-		return err
+		return fmt.Errorf("getting K8s server version: %w", err)
 	}
 	eksMajor := eksVersion.Major
 	eksMinor := strings.TrimFunc(eksVersion.Minor, func(r rune) bool {
@@ -27,12 +27,12 @@ func (b *Boatswain) CheckAmi(eksVersionOverride string) error {
 	}
 	latestAmi, err := b.AwsClient.GetLatestEKSAmi(eksMajor, eksMinor)
 	if err != nil {
-		return err
+		return fmt.Errorf("getting latest EKS AMI: %w", err)
 	}
 
 	asgs, err := b.AwsClient.GetAutoScalingGroups()
 	if err != nil {
-		return err
+		return fmt.Errorf("getting ASGs: %w", err)
 	}
 
 	// TODO: show AMI name instead of ID

--- a/cmd/boatswain/init.go
+++ b/cmd/boatswain/init.go
@@ -1,15 +1,23 @@
 package boatswain
 
 import (
+	"fmt"
+
 	"github.com/projectsyn/boatswain/pkg/aws"
 	"github.com/projectsyn/boatswain/pkg/k8sclient"
 )
 
-func New(awsAssumeRoleArn string) *Boatswain {
-	aws := aws.NewAwsClient(awsAssumeRoleArn)
-	k8s := k8sclient.NewK8sClient()
+func New(awsAssumeRoleArn string) (*Boatswain, error) {
+	aws, err := aws.NewAwsClient(awsAssumeRoleArn)
+	if err != nil {
+		return nil, fmt.Errorf("initializing AWS client: %w", err)
+	}
+	k8s, err := k8sclient.NewK8sClient()
+	if err != nil {
+		return nil, fmt.Errorf("initializing K8s client: %w", err)
+	}
 	return &Boatswain{
 		AwsClient: aws,
 		K8sClient: k8s,
-	}
+	}, nil
 }

--- a/cmd/boatswain/list_upgradable.go
+++ b/cmd/boatswain/list_upgradable.go
@@ -1,6 +1,8 @@
 package boatswain
 
 import (
+	"fmt"
+
 	"github.com/projectsyn/boatswain/pkg/aws"
 )
 
@@ -9,7 +11,7 @@ func (b *Boatswain) ListUpgradable() ([]*aws.Instance, error) {
 
 	asgs, err := b.AwsClient.GetAutoScalingGroups()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting ASGs: %w", err)
 	}
 
 	instances := []*aws.Instance{}

--- a/cmd/boatswain/upgrade.go
+++ b/cmd/boatswain/upgrade.go
@@ -17,7 +17,7 @@ func (b *Boatswain) Upgrade(singleNode string, forceReplace bool) error {
 
 	asgs, err := b.AwsClient.GetAutoScalingGroups()
 	if err != nil {
-		return err
+		return fmt.Errorf("getting ASGs: %w", err)
 	}
 
 	for _, asg := range asgs.Groups {

--- a/cmd/boatswain/upgrade.go
+++ b/cmd/boatswain/upgrade.go
@@ -2,6 +2,7 @@ package boatswain
 
 import (
 	"fmt"
+	"log"
 
 	boatswainpkg "github.com/projectsyn/boatswain/pkg/boatswain"
 )
@@ -33,7 +34,7 @@ func (b *Boatswain) Upgrade(singleNode string, forceReplace bool) error {
 							asg,
 							i,
 							nodes[i.InstancePrivateDnsName]); err != nil {
-							panic(err.Error())
+							log.Fatal(err.Error())
 						}
 					}
 				} else {
@@ -45,7 +46,7 @@ func (b *Boatswain) Upgrade(singleNode string, forceReplace bool) error {
 							asg,
 							i,
 							nodes[i.InstancePrivateDnsName]); err != nil {
-							panic(err.Error())
+							log.Fatal(err.Error())
 						}
 					}
 				}

--- a/commands.go
+++ b/commands.go
@@ -21,7 +21,10 @@ type CheckAmiCmd struct {
 }
 
 func (c *CheckAmiCmd) Run(ctx *kong.Context) error {
-	b := boatswain.New(c.AwsAssumeRoleArn)
+	b, err := boatswain.New(c.AwsAssumeRoleArn)
+	if err != nil {
+		return err
+	}
 	return b.CheckAmi(c.EksVersion)
 }
 
@@ -30,7 +33,10 @@ type ListUpgradableCmd struct {
 }
 
 func (c *ListUpgradableCmd) Run(ctx *kong.Context) error {
-	b := boatswain.New(c.AwsAssumeRoleArn)
+	b, err := boatswain.New(c.AwsAssumeRoleArn)
+	if err != nil {
+		return err
+	}
 	instances, err := b.ListUpgradable()
 	if err != nil {
 		return err
@@ -53,6 +59,9 @@ type UpgradeCmd struct {
 }
 
 func (c *UpgradeCmd) Run(ctx *kong.Context) error {
-	b := boatswain.New(c.AwsAssumeRoleArn)
+	b, err := boatswain.New(c.AwsAssumeRoleArn)
+	if err != nil {
+		return err
+	}
 	return b.Upgrade(c.SingleNode, c.ForceReplace)
 }

--- a/main.go
+++ b/main.go
@@ -3,8 +3,6 @@ package main
 import (
 	"fmt"
 
-	//	"github.com/projectsyn/boatswain/pkg/aws"
-	//	"github.com/projectsyn/boatswain/pkg/k8sclient"
 	"github.com/alecthomas/kong"
 )
 
@@ -73,13 +71,4 @@ func main() {
 
 	err := ctx.Run()
 	ctx.FatalIfErrorf(err)
-	//	awsClient := aws.NewAwsClient(os.Getenv("AWS_ASSUME_ROLE_ARN"))
-	//	k8sClient := k8sclient.NewK8sClient()
-	//
-	//	theNode := os.Getenv("NODE")
-	//	if theNode != "" {
-	//		fmt.Println("only considering", theNode)
-	//	}
-	//
-	//	forceReplace, err := strconv.ParseBool(os.Getenv("FORCE_REPLACE"))
 }

--- a/pkg/aws/init.go
+++ b/pkg/aws/init.go
@@ -37,7 +37,11 @@ func NewAwsClient(roleArn string) (*AwsClient, error) {
 
 	c := &AwsClient{}
 
-	c.Session = session.New()
+	var err error
+	c.Session, err = session.NewSession()
+	if err != nil {
+		return nil, err
+	}
 
 	if roleArn != "" {
 		creds := stscreds.NewCredentials(c.Session, roleArn)

--- a/pkg/aws/init.go
+++ b/pkg/aws/init.go
@@ -24,7 +24,7 @@ func verifyAwsEnvVars() error {
 	for _, e := range awsEnvVars {
 		_, ok := os.LookupEnv(e)
 		if !ok {
-			return fmt.Errorf("Environment variable %s is mandatory", e)
+			return fmt.Errorf("environment variable %s is mandatory", e)
 		}
 	}
 	return nil

--- a/pkg/aws/init.go
+++ b/pkg/aws/init.go
@@ -1,6 +1,9 @@
 package aws
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -9,7 +12,29 @@ import (
 	"github.com/aws/aws-sdk-go/service/ssm"
 )
 
-func NewAwsClient(roleArn string) *AwsClient {
+var (
+	awsEnvVars = []string{
+		"AWS_REGION",
+		"AWS_ACCESS_KEY_ID",
+		"AWS_SECRET_ACCESS_KEY",
+	}
+)
+
+func verifyAwsEnvVars() error {
+	for _, e := range awsEnvVars {
+		_, ok := os.LookupEnv(e)
+		if !ok {
+			return fmt.Errorf("Environment variable %s is mandatory", e)
+		}
+	}
+	return nil
+}
+
+func NewAwsClient(roleArn string) (*AwsClient, error) {
+	if err := verifyAwsEnvVars(); err != nil {
+		return nil, err
+	}
+
 	c := &AwsClient{}
 
 	c.Session = session.New()
@@ -23,5 +48,5 @@ func NewAwsClient(roleArn string) *AwsClient {
 	c.EC2 = ec2.New(c.Session, c.Config)
 	c.SSM = ssm.New(c.Session, c.Config)
 
-	return c
+	return c, nil
 }

--- a/pkg/aws/instance.go
+++ b/pkg/aws/instance.go
@@ -22,10 +22,10 @@ func (c *AwsClient) getInstancePrivateDnsName(instanceId *string) (*string, erro
 		return nil, err
 	}
 	if len(result.Reservations) == 0 {
-		return nil, fmt.Errorf("No reservation found for id %v", *instanceId)
+		return nil, fmt.Errorf("no reservation found for id %v", *instanceId)
 	}
 	if len(result.Reservations[0].Instances) == 0 {
-		return nil, fmt.Errorf("No instance found for id %v", *instanceId)
+		return nil, fmt.Errorf("no instance found for id %v", *instanceId)
 	}
 	return result.Reservations[0].Instances[0].PrivateDnsName, nil
 }
@@ -43,7 +43,7 @@ func (c *AwsClient) getInstanceAvailabilityZone(instanceId *string) (*string, er
 		return nil, err
 	}
 	if len(result.InstanceStatuses) == 0 {
-		return nil, fmt.Errorf("No InstanceStatus available for id %v", *instanceId)
+		return nil, fmt.Errorf("no InstanceStatus available for id %v", *instanceId)
 	}
 	return result.InstanceStatuses[0].AvailabilityZone, nil
 }
@@ -87,7 +87,7 @@ func (c *AwsClient) makeInstanceFromId(instanceId string) (*Instance, error) {
 		return nil, err
 	}
 	if len(result.AutoScalingInstances) == 0 {
-		return nil, fmt.Errorf("Unable to find AutoScaling instance with id %v", instanceId)
+		return nil, fmt.Errorf("unable to find AutoScaling instance with id %v", instanceId)
 	}
 
 	return c.makeInstanceFromDetails(result.AutoScalingInstances[0])

--- a/pkg/boatswain/replace_node.go
+++ b/pkg/boatswain/replace_node.go
@@ -44,7 +44,7 @@ func ReplaceAsgNode(awsClient *aws.AwsClient, k8sClient *k8sclient.K8sClient,
 		if err := k8sClient.DrainNode(node); err != nil {
 			fmt.Println("Drain error: ", err)
 			if err == k8sclient.ErrTransientDrain {
-				time.Sleep(5)
+				time.Sleep(5 * time.Second)
 				continue
 			}
 			fmt.Println("Ignoring error...")

--- a/pkg/boatswain/replace_node.go
+++ b/pkg/boatswain/replace_node.go
@@ -39,11 +39,6 @@ func ReplaceAsgNode(awsClient *aws.AwsClient, k8sClient *k8sclient.K8sClient,
 	fmt.Printf("New node %v ready\n", newNode.ObjectMeta.Name)
 	// 5. Drain old node
 	fmt.Println("Drain old node")
-	//if err := k8sClient.DrainNode(node); err != nil {
-	//	// XXX retry drain here
-	//	fmt.Println("Error while draining, continuing anyway...")
-	//	fmt.Println(err.Error())
-	//}
 	retryDrain := true
 	for retryDrain {
 		if err := k8sClient.DrainNode(node); err != nil {

--- a/pkg/boatswain/replace_node.go
+++ b/pkg/boatswain/replace_node.go
@@ -43,7 +43,7 @@ func ReplaceAsgNode(awsClient *aws.AwsClient, k8sClient *k8sclient.K8sClient,
 	for retryDrain {
 		if err := k8sClient.DrainNode(node); err != nil {
 			fmt.Println("Drain error: ", err)
-			if err == k8sclient.TransientDrainError {
+			if err == k8sclient.ErrTransientDrain {
 				time.Sleep(5)
 				continue
 			}

--- a/pkg/k8sclient/init.go
+++ b/pkg/k8sclient/init.go
@@ -1,7 +1,6 @@
 package k8sclient
 
 import (
-	"log"
 	"os"
 	"time"
 
@@ -10,7 +9,7 @@ import (
 	"k8s.io/kubectl/pkg/drain"
 )
 
-func NewK8sClient() *K8sClient {
+func NewK8sClient() (*K8sClient, error) {
 	// if you want to change the loading rules (which files in which order), you can do so here
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 
@@ -20,13 +19,13 @@ func NewK8sClient() *K8sClient {
 	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
 	config, err := kubeConfig.ClientConfig()
 	if err != nil {
-		log.Fatal(err.Error())
+		return nil, err
 	}
 
 	// create the clientset
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		log.Fatal(err.Error())
+		return nil, err
 	}
 	d := &drain.Helper{
 		Client: clientset,
@@ -43,5 +42,5 @@ func NewK8sClient() *K8sClient {
 		Client:  clientset,
 		config:  config,
 		Drainer: d,
-	}
+	}, nil
 }

--- a/pkg/k8sclient/init.go
+++ b/pkg/k8sclient/init.go
@@ -1,6 +1,7 @@
 package k8sclient
 
 import (
+	"log"
 	"os"
 	"time"
 
@@ -19,13 +20,13 @@ func NewK8sClient() *K8sClient {
 	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
 	config, err := kubeConfig.ClientConfig()
 	if err != nil {
-		panic(err.Error())
+		log.Fatal(err.Error())
 	}
 
 	// create the clientset
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		panic(err.Error())
+		log.Fatal(err.Error())
 	}
 	d := &drain.Helper{
 		Client: clientset,

--- a/pkg/k8sclient/init.go
+++ b/pkg/k8sclient/init.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"time"
 
-	//"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/kubectl/pkg/drain"

--- a/pkg/k8sclient/node.go
+++ b/pkg/k8sclient/node.go
@@ -33,7 +33,7 @@ func (c *K8sClient) CordonNode(node *corev1.Node) error {
 	return drain.RunCordonOrUncordon(c.Drainer, node, true)
 }
 
-var TransientDrainError = errors.New("Server unable to handle drain request")
+var ErrTransientDrain = errors.New("server unable to handle drain request")
 
 func (c *K8sClient) DrainNode(node *corev1.Node) error {
 	fmt.Println("Draining node", node.ObjectMeta.Name)
@@ -46,7 +46,7 @@ func (c *K8sClient) DrainNode(node *corev1.Node) error {
 		if strings.HasPrefix(errStr, "[error when evicting pod") {
 			realErrStr := strings.SplitN(errStr, ": ", 2)[1]
 			if strings.HasPrefix(realErrStr, "the server is currently unable to handle the request") {
-				return TransientDrainError
+				return ErrTransientDrain
 			}
 		}
 	}

--- a/pkg/k8sclient/node.go
+++ b/pkg/k8sclient/node.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	//"k8s.io/apimachinery/pkg/api/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubectl/pkg/drain"

--- a/pkg/k8sclient/node.go
+++ b/pkg/k8sclient/node.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -15,7 +16,7 @@ import (
 func (c *K8sClient) GetNodes() NodeMap {
 	nodes, err := c.Client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		panic(err.Error())
+		log.Fatal(err.Error())
 	}
 	nodesByName := NodeMap{}
 	for _, node := range nodes.Items {

--- a/pkg/k8sclient/pending.go
+++ b/pkg/k8sclient/pending.go
@@ -11,7 +11,7 @@ import (
 func (c *K8sClient) WaitUntilNoPodsPending() error {
 	// TODO: consider WaitGroup and go-routine, instead of sleeping on
 	// main thread
-	for true {
+	for {
 		pods, err := c.Client.CoreV1().Pods("").List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			return err


### PR DESCRIPTION
* Remove all panics (note some of them have been replaced by `log.Fatal` which is not much better)
* Propagate errors back to Kong (CLI library) and let it handle the printing
* Remove dead (commented-out) code
* Address issues reported by `staticcheck`

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
